### PR TITLE
Z1 dungeons

### DIFF
--- a/ideas.md
+++ b/ideas.md
@@ -80,7 +80,10 @@ Mapping:
         $408000-$409FFF -> $6000-$7FFF  (Regular M1 Work RAM)
     
     Mother Brain
-        $40A000-$40C7FF -> Randomizer   (12kb of extra SRAM for Mother Brain use: stats, timers, temporary item buffers etc)
+        $40A000-$40B7FF -> Randomizer   (6kb of extra SRAM for Mother Brain use: stats, timers)
+        $40B800-$40BC7F -> Z1 Exp RAM   (1kb backup of Z1 Expandanded dungeon state)
+        $40BC80-$40BFFF -> Randomizer   (1kb extra randomizer SRAM)
+        $40C000-$40C7FF -> Randomizer   (2kb of item buffers)
         $40C800-$40CFFF -> Z1 NES RAM   (2kb backup of Z1 NES RAM State)
         $40D000-$40D7FF -> M1 NES RAM   (2kb backup of M1 NES RAM State)
         $40D800-$40DFFF -> SA-1 WRAM    (Used by menu code and more)

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -61,6 +61,7 @@ print "SRAM buffer ends at ", hex(!INVENTORY_TEMP_3)
 !SRAM_ALTTP_SPC_BUF = $40AC00 ; to $40ACFF
 
 !SRAM_RANDOLIVE = $40AD00   ; to $40AEFF
+!SRAM_Z1_EXPANDED_DUNGEONS = $40B800 ; to $40BC7F
 
 ;  Z1 sram
 !SRAM_Z1_Start = $406000

--- a/src/m1/init.asm
+++ b/src/m1/init.asm
@@ -9,7 +9,7 @@ SnesBoot:
     LDA.l ((!BASE_BANK+7)<<16)+$8000, x
     STA.l (!BASE_BANK<<16)+$1000, x
     INX #2
-    CPX #$1000
+    CPX #$0C00
     BNE -
 
     JSL spc_init_driver

--- a/src/motherbrain/transition.asm
+++ b/src/motherbrain/transition.asm
@@ -142,9 +142,10 @@ z1_transition_table:
 
     ; Restore WRAM from BW-RAM backup
     dw $0003, $C800, $0040, $0000, $0000, $0800
+    dw $0003, !SRAM_Z1_EXPANDED_DUNGEONS&$ffff, !SRAM_Z1_EXPANDED_DUNGEONS>>16, $1B80, $0000, $0480
 
     ; Copy common routines from ROM -> RAM
-    dw $0003, $8000, $0087, $1000, $0000, $1000
+    dw $0003, $8000, $0087, $1000, $0000, $0C00
 
     ; Set up IRQ/NMI handlers
     dw $0004, $105c, !IRAM_NMI
@@ -169,7 +170,7 @@ m1_transition_table:
     dw $0003, $D000, $0040, $0000, $0000, $0800
 
     ; Copy common routines from ROM -> RAM
-    dw $0003, $8000, $0097, $1000, $0000, $1000
+    dw $0003, $8000, $0097, $1000, $0000, $0C00
 
     ; Set up IRQ/NMI handlers
     dw $0004, $105c, !IRAM_NMI

--- a/src/z1/common.asm
+++ b/src/z1/common.asm
@@ -272,6 +272,30 @@ SnesTransferPatternBlock_Indexed:
 .Exit
     PLP
     INC.w PatternBlockIndex       ; Mark this block finished, and we're ready for the next one.
+
+    ; When the UW boss block (index 3) finishes, PatternBlockIndex
+    ; becomes 4. At that point TransferLevelPatternBlocks has loaded
+    ; the level-native sprite set ($09E0) and boss set ($0C00) into
+    ; VRAM. Sync the per-room swap tracking vars to match, so a room
+    ; whose enemy needs a different block actually re-triggers a swap.
+    ; Without this, CurrentSpriteSet/CurrentBossSet can be left over
+    ; from the previous level and HandleRoomSpriteSwap would wrongly
+    ; skip the DMA, showing the wrong enemy graphics (e.g. darknuts
+    ; rendered with another set's tiles).
+if not(defined("STANDALONE"))
+    php : sep #$30
+    lda.w PatternBlockIndex
+    cmp #$04
+    bne .NoSync
+    ldx.b CurLevel
+    lda.l LevelToSpriteSet, x
+    sta.w CurrentSpriteSet
+    lda.l LevelToBossSet, x
+    sta.w CurrentBossSet
+.NoSync
+    plp
+endif
+
     PLY : PLX
     lda PPUCNT1ZP : jsr WritePPUCTRL1
     RTS

--- a/src/z1/init.asm
+++ b/src/z1/init.asm
@@ -10,7 +10,7 @@ SnesBoot:
     LDA.l ((!BASE_BANK+7)<<16)+$8000, x
     STA.l (!BASE_BANK<<16)+$1000, x
     INX #2
-    CPX #$1000
+    CPX #$0C00
     BNE -
 
     jsl spc_init_dpcm
@@ -31,6 +31,11 @@ if not(defined("STANDALONE"))
     jsl UploadItemPalettes
 endif
     jsl nes_overlay_init
+
+if not(defined("STANDALONE"))
+    jsl PreConvertSpritePatterns
+endif
+
     JML (!BASE_BANK<<16)+$FF76 ; Startup
 
 SnesInit:

--- a/src/z1/labels.asm
+++ b/src/z1/labels.asm
@@ -614,6 +614,8 @@ PalIdx = $0B0E
 
 NeedsBGPriorityUpdate = $0B22
 
+DungeonCopyLength = $0A10
+
 PPUAddrTmpLo = $0A30
 PPUAddrTmpHi = $0A32
 ScrollYDMA = $0A40

--- a/src/z1/labels.asm
+++ b/src/z1/labels.asm
@@ -632,6 +632,8 @@ ButtonsDownSnes = $0A4C
 ExitRoomTemp = $0A50
 ExitRoomTable = $0A52
 
+ExtendedItemTemp = $0A58
+
 ; Dynamic items
 DynamicItemIndexes = $0A60
 
@@ -659,3 +661,11 @@ QuickSwapIndex = $0A9C
 
 ; Item animations
 ;struct Animations $0aa0  ;  Already defined in common/nes/items.asm; but don't put anything else here
+
+; Expanded dungeons
+ExpandedDungeonState = $1B80
+
+; Pre-converted sprite patterns
+SpritePatternData = $7F1000
+CurrentSpriteSet = $0AB0
+CurrentBossSet = $0AB1

--- a/src/z1/randomizer/common.asm
+++ b/src/z1/randomizer/common.asm
@@ -33,3 +33,11 @@ InitMode8_SaveItems:
     jsl SaveItems
     jsr $E625
     rts
+
+; =============================================
+; Expanded dungeons support
+; =============================================
+
+CopyBlock_Common:
+    jsl CopyBlock_LevelData
+    rts

--- a/src/z1/randomizer/common.asm
+++ b/src/z1/randomizer/common.asm
@@ -41,3 +41,12 @@ InitMode8_SaveItems:
 CopyBlock_Common:
     jsl CopyBlock_LevelData
     rts
+
+; =============================================
+; Sprite pattern swap hook for room transitions
+; =============================================
+
+InitMode_EnterRoom_SpriteHook:
+    jsr $EA3D                   ; Call original subroutine
+    jsl HandleRoomSpriteSwap    ; Check if sprite tiles need swapping
+    rts

--- a/src/z1/randomizer/dungeons.asm
+++ b/src/z1/randomizer/dungeons.asm
@@ -1,0 +1,38 @@
+; Expanded dungeons support
+; This allows dungeons to use level blocks from banks other than bank 6.
+; Meaning we can have a full set of unique dungeon level blocks for all 9 dungeons.
+
+; Params:
+; [$00:01]: source address
+; [$02:03]: destination address
+; [$04:05]: end destination address
+;
+; Also increments submode.
+;
+CopyBlock_LevelData:
+    PHX : PHP
+    REP #$30
+    LDY #$0000
+    LDX #$0000
+    
+    LDA $04
+    SEC : SBC $02 : INC
+    STA.w DungeonCopyLength
+    LDA $02 : STA $04
+
+    LDA.w CurLevel : AND #$00FF : TAX
+    LDA.l LevelBlockBanksQ1, x
+
+    SEP #$20
+    STA $02
+
+.loop
+    LDA.b [$00], Y
+    STA.b ($04), Y
+    INY
+    CPY.w DungeonCopyLength
+    BNE .loop
+    PLP : PLX
+    INC GameSubmode
+    RTL
+

--- a/src/z1/randomizer/hooks.asm
+++ b/src/z1/randomizer/hooks.asm
@@ -162,3 +162,12 @@ org $829035
 ; Go to submode 1 of menu 
 org $82A596
     dw $a5df
+
+; =============================================
+; Expanded dungeons support
+; =============================================
+
+; Hook CopyBlock to use expanded version
+org $86806C
+    jsr CopyBlock_Common
+

--- a/src/z1/randomizer/hooks.asm
+++ b/src/z1/randomizer/hooks.asm
@@ -171,3 +171,13 @@ org $82A596
 org $86806C
     jsr CopyBlock_Common
 
+; =============================================
+; Sprite pattern swap for generated dungeons
+; =============================================
+
+; Hook InitMode_EnterRoom - JSR $EA3D at $87C6
+; This runs when a room has scrolled into view and is loaded,
+; but before sprites are shown.
+org $8587C6
+    jsr InitMode_EnterRoom_SpriteHook
+

--- a/src/z1/randomizer/main.asm
+++ b/src/z1/randomizer/main.asm
@@ -9,6 +9,7 @@ incsrc "caves.asm"
 incsrc "ending.asm"
 incsrc "quickswap.asm"
 incsrc "goals.asm"
+incsrc "dungeons.asm"
 
 org $8A8000
 incsrc "tables.asm"

--- a/src/z1/randomizer/main.asm
+++ b/src/z1/randomizer/main.asm
@@ -10,6 +10,7 @@ incsrc "ending.asm"
 incsrc "quickswap.asm"
 incsrc "goals.asm"
 incsrc "dungeons.asm"
+incsrc "spritepatterns.asm"
 
 org $8A8000
 incsrc "tables.asm"

--- a/src/z1/randomizer/newitems.asm
+++ b/src/z1/randomizer/newitems.asm
@@ -106,10 +106,17 @@ TakeItem_SetItemValueFF_extended:
 ; Loads the underworld room item Id from our extended tables instead of from
 ; the original level data (this lets us use the full 8-bit for item id:s)
 ;
+print "LoadRoomItemIdUW_extended = ", pc
 LoadRoomItemIdUW_extended:
     phx
     ldy $EB
-    
+
+    ; Was the dungeon data moved and extended?
+    ldx.b $10
+    lda.l LevelBlockBanksQ1, x
+    cmp.b #$86
+    bne .extended
+
     ; Load dungeon id
     lda.b $10
     cmp.b #$07
@@ -120,6 +127,23 @@ LoadRoomItemIdUW_extended:
     tyx
 .loadItem
     lda.l RoomItemsUW_extended, x
+    plx
+    cmp.b #$2F
+    rtl
+
+; Loads from a separate table depending on dungeon id
+; dungeon id is in [X]
+.extended
+    rep #$30
+    txa
+    and.w #$00ff
+    xba : lsr : and.w #$7fff
+    sta.w ExtendedItemTemp 
+    lda.b $eb : and.w #$00ff
+    clc : adc.w ExtendedItemTemp
+    tax
+    lda.l RoomItemsUW_extended_custom, x
+    sep #$30
     plx
     cmp.b #$2F
     rtl

--- a/src/z1/randomizer/spritepatterns.asm
+++ b/src/z1/randomizer/spritepatterns.asm
@@ -1,0 +1,355 @@
+; =============================================
+; Pre-converted Sprite Pattern Data
+; =============================================
+;
+; Converts all unique Z1 underworld sprite pattern blocks
+; from NES 2bpp to SNES 4bpp format at boot/transition time.
+;
+; NES 2bpp tile: 16 bytes (8 plane0 + 8 plane1)
+; SNES 4bpp tile: 32 bytes (8 words plane0:plane1 + 8 zero words)
+;
+
+; WRAM offsets for each pre-converted block
+!PCSP_UWBG     = $1000
+!PCSP_UWSP     = $2040
+!PCSP_SP127    = $2240
+!PCSP_SP358    = $2680
+!PCSP_SP469    = $2AC0
+!PCSP_BOSS1257 = $2F00
+!PCSP_BOSS3468 = $3700
+!PCSP_BOSS9    = $3F00
+!PCSP_END      = $4700
+
+; NES ROM source addresses in SNES bank $83 (NES bank 3)
+!NES_UWBG      = $83811B
+!NES_UWSP      = $839CBB
+!NES_SP127     = $839DBB
+!NES_SP358     = $83987B
+!NES_SP469     = $839A9B
+!NES_BOSS1257  = $839FDB
+!NES_BOSS3468  = $83A3DB
+!NES_BOSS9     = $83A7DB
+
+; =============================================
+; Source table: 24-bit ROM address + 16-bit NES byte count
+; 5 bytes per entry, 8 entries
+; =============================================
+SpritePatternSourceTable:
+    dl !NES_UWBG     : dw $0820    ; 0: UW Background
+    dl !NES_UWSP     : dw $0100    ; 1: UW Common Sprites
+    dl !NES_SP127    : dw $0220    ; 2: Enemy sprites for levels 1,2,7
+    dl !NES_SP358    : dw $0220    ; 3: Enemy sprites for levels 3,5,8
+    dl !NES_SP469    : dw $0220    ; 4: Enemy sprites for levels 4,6,9
+    dl !NES_BOSS1257 : dw $0400    ; 5: Boss sprites for levels 1,2,5,7
+    dl !NES_BOSS3468 : dw $0400    ; 6: Boss sprites for levels 3,4,6,8
+    dl !NES_BOSS9    : dw $0400    ; 7: Boss sprites for level 9
+SpritePatternSourceTableEnd:
+
+; =============================================
+; Level (0-9) to set index mappings
+; Index refers to PreconvertedBlockInfo entries
+; =============================================
+LevelToSpriteSet:
+    db $02  ; Level 0 (unused/overworld, defaults to SP127)
+    db $02  ; Level 1 → SP127
+    db $02  ; Level 2 → SP127
+    db $03  ; Level 3 → SP358
+    db $04  ; Level 4 → SP469
+    db $03  ; Level 5 → SP358
+    db $04  ; Level 6 → SP469
+    db $02  ; Level 7 → SP127
+    db $03  ; Level 8 → SP358
+    db $04  ; Level 9 → SP469
+
+LevelToBossSet:
+    db $05  ; Level 0 → Boss1257
+    db $05  ; Level 1 → Boss1257
+    db $05  ; Level 2 → Boss1257
+    db $06  ; Level 3 → Boss3468
+    db $06  ; Level 4 → Boss3468
+    db $05  ; Level 5 → Boss1257
+    db $06  ; Level 6 → Boss3468
+    db $05  ; Level 7 → Boss1257
+    db $06  ; Level 8 → Boss3468
+    db $07  ; Level 9 → Boss9
+
+; =============================================
+; Pre-converted block info for DMA
+; 6 bytes per entry: WRAM offset, SNES size, VRAM target
+; =============================================
+PreconvertedBlockInfo:
+    dw !PCSP_UWBG,     $1040, $1700    ; 0: UW Background
+    dw !PCSP_UWSP,     $0200, $08E0    ; 1: UW Common Sprites
+    dw !PCSP_SP127,    $0440, $09E0    ; 2: SP127
+    dw !PCSP_SP358,    $0440, $09E0    ; 3: SP358
+    dw !PCSP_SP469,    $0440, $09E0    ; 4: SP469
+    dw !PCSP_BOSS1257, $0800, $0C00    ; 5: Boss1257
+    dw !PCSP_BOSS3468, $0800, $0C00    ; 6: Boss3468
+    dw !PCSP_BOSS9,    $0800, $0C00    ; 7: Boss9
+
+print "PreConvertSpritePatterns = ", pc
+
+; =============================================
+; PreConvertSpritePatterns
+; =============================================
+; Converts all NES 2bpp pattern blocks to SNES 4bpp
+; and writes them sequentially to WRAM at $7F1000.
+;
+; Called at boot (init.asm) and on transition to Z1.
+; Must be called with screen off. Uses DP $00-$07.
+;
+PreConvertSpritePatterns:
+    phx : phy
+    php
+
+    sep #$20
+
+    ; Reset loaded set tracking so first room always triggers DMA
+    lda #$FF
+    sta.w CurrentSpriteSet
+    sta.w CurrentBossSet
+
+    ; Set WRAM write address to $7F:1000
+    ; WRAM port address: bit 16 = 1 (bank $7F), bits 0-15 = 1000
+    stz $2181
+    lda #$10
+    sta $2182
+    lda #$01
+    sta $2183
+
+    rep #$30
+    ldx #$0000
+
+.NextBlock:
+    cpx.w #SpritePatternSourceTableEnd-SpritePatternSourceTable
+    bcs .AllDone
+
+    ; Load 24-bit source address into $00-$02
+    lda.l SpritePatternSourceTable+0, x
+    sta $00
+    sep #$20
+    lda.l SpritePatternSourceTable+2, x
+    sta $02
+    rep #$20
+
+    ; Load NES byte count into $06-$07
+    lda.l SpritePatternSourceTable+3, x
+    sta $06
+
+    ; Advance table index to next entry (5 bytes per entry)
+    txa : clc : adc #$0005 : tax
+    phx
+
+    sep #$20
+
+.ConvertTile:
+    ldy #$0008              ; Y = plane 1 offset (8 bytes ahead)
+    ldx #$0008              ; X = row counter
+
+.Row:
+    lda [$00]               ; Read plane 0 byte from NES source
+    sta $2180               ; Write to WRAM (auto-increment)
+    lda [$00], y            ; Read plane 1 byte (source + 8)
+    sta $2180               ; Write to WRAM (auto-increment)
+
+    rep #$20
+    inc $00                 ; Advance source pointer (16-bit inc of $00-$01)
+    dec $06                 ; Decrement remaining NES bytes
+    lda $06
+    beq .BlockDone
+    sep #$20
+
+    dex
+    bne .Row
+
+    ; 8 rows done - skip 8 source bytes (plane 1 data already read via Y)
+    rep #$20
+    lda $00
+    clc : adc #$0008
+    sta $00
+    lda $06
+    cmp #$0008
+    bcc .BlockDone
+    sec : sbc #$0008
+    sta $06
+
+    ; Write 16 zero bytes for SNES planes 2-3
+    sep #$20
+    ldx #$0010
+-
+    stz $2180
+    dex
+    bne -
+
+    ; Check if more tiles remain
+    lda $06 : ora $07
+    beq .BlockDone
+    bra .ConvertTile
+
+.BlockDone:
+    rep #$30
+    plx
+    jmp .NextBlock
+
+.AllDone:
+    plp
+    ply : plx
+    rtl
+
+print "QueueSpritePatternDMA = ", pc
+
+; =============================================
+; QueueSpritePatternDMA
+; =============================================
+; Queues a pre-converted pattern block for DMA to VRAM
+; during the next VBlank via the PPU data string system.
+;
+; Input: A (8-bit) = block index (0-7) from PreconvertedBlockInfo
+; Can be called at any time (not just during VBlank).
+;
+QueueSpritePatternDMA:
+    phx : phy
+    php
+ 
+    rep #$30
+
+    ; Calculate table offset: index * 6
+    and #$00FF
+    sta $08
+    asl                         ; ×2
+    clc : adc $08               ; ×3
+    asl                         ; ×6
+    tax
+
+    ; Load block info into scratch regs before building PPU string
+    lda.l PreconvertedBlockInfo+0, x
+    sta $08                     ; WRAM source offset
+    lda.l PreconvertedBlockInfo+2, x
+    sta $0A                     ; SNES transfer size
+    lda.l PreconvertedBlockInfo+4, x
+    sta $0C                     ; VRAM target address
+
+    ; Set up pointer to PPU data string buffer
+    lda.l #SnesPPUDataString
+    sta $F0
+    lda.l #(SnesPPUDataString>>8)
+    sta $F1
+
+    ; Get current write position
+    lda.l SnesPPUDataStringPtr
+    tay
+
+    ; Write Indirect DMA entry (type $0005)
+    ; +0: Type
+    lda #$0005
+    sta [$F0], y
+    iny #2
+
+    ; +2: VRAM target address
+    lda $0C
+    sta [$F0], y
+    iny #4                      ; Skip +4 padding (matches processor iny #4)
+
+    ; +6: Transfer length
+    lda $0A
+    sta [$F0], y
+    iny #2
+
+    ; +8: Source address (WRAM offset within bank $7F)
+    lda $08
+    sta [$F0], y
+    iny #2
+
+    ; +10: Source bank ($7F)
+    lda #$007F
+    sta [$F0], y
+    iny #2
+
+    ; Write terminator
+    lda #$0000
+    sta [$F0], y
+
+    ; Update write pointer
+    tya
+    sta.l SnesPPUDataStringPtr
+
+    plp
+    ply : plx
+    rtl
+
+print "HandleRoomSpriteSwap = ", pc
+
+; =============================================
+; HandleRoomSpriteSwap
+; =============================================
+; Called from InitMode_EnterRoom_SpriteHook when a new
+; underworld room has been loaded and scrolled into view.
+;
+; Reads the current room's enemy_id from level block data:
+;   EnemyCode = LevelBlockAttrsC[room] & $3F  (Table 3, bits 5:0)
+;   EnemyMode = LevelBlockAttrsD[room] & $80  (Table 4, bit 7)
+;   enemy_id  = (EnemyMode >> 1) | EnemyCode  (7-bit, 0-127)
+;
+; Looks up EnemyIdToSpriteBlock[enemy_id] to get the
+; pre-converted block index to DMA:
+;   2-4 = sprite set (SP127/SP358/SP469) → updates CurrentSpriteSet
+;   5-7 = boss set (Boss1257/Boss3468/Boss9) → updates CurrentBossSet
+;   $FF = no swap needed (common sprites only)
+;
+HandleRoomSpriteSwap:
+    phx : phy
+    php
+
+    sep #$30
+
+    ; Only process underworld rooms (level > 0)
+    lda.b CurLevel
+    beq .Exit
+    cmp #$0A
+    bcs .Exit
+
+    ; Get room_id
+    lda.b RoomId
+    and #$7F
+    tax
+
+    ; Build enemy_id from level block data
+    ; EnemyCode = Table 3 bits 5:0
+    lda.w LevelBlockAttrsC, x
+    and #$3F
+    sta $08
+
+    ; EnemyMode = Table 4 bit 7 → shift to bit 6
+    lda.w LevelBlockAttrsD, x
+    and #$80
+    lsr
+    ora $08                     ; enemy_id = EnemyMode[6] | EnemyCode[5:0]
+    tax
+
+    ; Look up which block this enemy needs
+    lda.l EnemyIdToSpriteBlock, x
+    cmp #$FF
+    beq .Exit
+
+    ; Determine if sprite set (2-4) or boss set (5-7)
+    cmp #$05
+    bcs .IsBossSet
+
+    ; Sprite set (2-4): compare against CurrentSpriteSet
+    cmp.w CurrentSpriteSet
+    beq .Exit
+    sta.w CurrentSpriteSet
+    jsl QueueSpritePatternDMA
+    bra .Exit
+
+.IsBossSet:
+    ; Boss set (5-7): compare against CurrentBossSet
+    cmp.w CurrentBossSet
+    beq .Exit
+    sta.w CurrentBossSet
+    jsl QueueSpritePatternDMA
+
+.Exit:
+    plp
+    ply : plx
+    rtl

--- a/src/z1/randomizer/tables.asm
+++ b/src/z1/randomizer/tables.asm
@@ -269,4 +269,19 @@ Anim_ItemFrameTiles_extended:
     db $00, $00, $00, $00, $00, $00, $00, $4F ; 38-3f
 
 
+; Bank pointers for the level block data for each dungeon
+; Place at a known location for easy patching
+org $8A8600
+LevelBlockBanksQ1:
+    db $86 ; Overworld
+    db $86 ; Dungeon 1
+    db $86 ; Dungeon 2
+    db $86 ; Dungeon 3
+    db $86 ; Dungeon 4
+    db $86 ; Dungeon 5
+    db $86 ; Dungeon 6
+    db $86 ; Dungeon 7
+    db $86 ; Dungeon 8
+    db $86 ; Dungeon 9
+
 

--- a/src/z1/randomizer/tables.asm
+++ b/src/z1/randomizer/tables.asm
@@ -2,7 +2,7 @@
 ; Repointed Room Items
 ;
 RoomItemsUW_extended:
-print "RoooItemsExtended = ", pc
+print "RoomItemsExtended = ", pc
 
 ; Levels 1-6
 db $2F, $19, $2F, $1B, $05, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $1B, $1B, $1A, $0C
@@ -284,99 +284,6 @@ LevelBlockBanksQ1:
     db $86 ; Dungeon 8
     db $86 ; Dungeon 9
 
-org $8A9000
-RoomItemsUW_extended_custom:
-.level0
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-.level1
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-.level2
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-.level3
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-.level4
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-.level5
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-.level6
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-.level7
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-.level8
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-.level9
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
-
 ; =============================================
 ; Enemy ID to sprite block lookup table (128 bytes)
 ; Indexed by enemy_id: (EnemyMode << 6) | EnemyCode
@@ -391,9 +298,8 @@ RoomItemsUW_extended_custom:
 ;   $06 = Boss3468 (boss sprites for levels 3,4,6,8)
 ;   $07 = Boss9    (boss sprites for level 9)
 ;   $FF = no swap needed (uses common UW sprites)
-;
-; Place at known location for easy patching by randomizer
-org $8AA000
+
+org $8A8700
 EnemyIdToSpriteBlock:
     ; Mode 0: $00-$0F
     db $FF  ; $00 Nothing
@@ -519,3 +425,97 @@ EnemyIdToSpriteBlock:
     db $04  ; $7D List 27: Bubbles/Wizzrobes → SP469
     db $03  ; $7E List 28: Bubbles/Darknuts → SP358
     db $02  ; $7F List 29: Bubbles/Wallmaster → SP127
+
+org $8A9000
+RoomItemsUW_extended_custom:
+.level0
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level1
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level2
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level3
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level4
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level5
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level6
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level7
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level8
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level9
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+

--- a/src/z1/randomizer/tables.asm
+++ b/src/z1/randomizer/tables.asm
@@ -284,4 +284,238 @@ LevelBlockBanksQ1:
     db $86 ; Dungeon 8
     db $86 ; Dungeon 9
 
+org $8A9000
+RoomItemsUW_extended_custom:
+.level0
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level1
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level2
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level3
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level4
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level5
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level6
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level7
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level8
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+.level9
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
+    db $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F, $2F
 
+; =============================================
+; Enemy ID to sprite block lookup table (128 bytes)
+; Indexed by enemy_id: (EnemyMode << 6) | EnemyCode
+;   Mode 0 enemies: $00-$3F
+;   Mode 1 enemies: $40-$7F
+;
+; Values: block index from PreconvertedBlockInfo
+;   $02 = SP127  (enemy sprites for levels 1,2,7)
+;   $03 = SP358  (enemy sprites for levels 3,5,8)
+;   $04 = SP469  (enemy sprites for levels 4,6,9)
+;   $05 = Boss1257 (boss sprites for levels 1,2,5,7)
+;   $06 = Boss3468 (boss sprites for levels 3,4,6,8)
+;   $07 = Boss9    (boss sprites for level 9)
+;   $FF = no swap needed (uses common UW sprites)
+;
+; Place at known location for easy patching by randomizer
+org $8AA000
+EnemyIdToSpriteBlock:
+    ; Mode 0: $00-$0F
+    db $FF  ; $00 Nothing
+    db $FF  ; $01 Blue Lynel (OW)
+    db $FF  ; $02 Red Lynel (OW)
+    db $FF  ; $03 Blue Moblin (OW)
+    db $FF  ; $04 Red Moblin (OW)
+    db $02  ; $05 Blue Goriya → SP127
+    db $02  ; $06 Red Goriya → SP127
+    db $FF  ; $07 Red Octorok 1 (OW)
+    db $FF  ; $08 Red Octorok 2 (OW)
+    db $FF  ; $09 Blue Octorok 1 (OW)
+    db $FF  ; $0A Blue Octorok 2 (OW)
+    db $03  ; $0B Red Darknut → SP358
+    db $03  ; $0C Blue Darknut → SP358
+    db $FF  ; $0D Blue Tektite (OW)
+    db $FF  ; $0E Red Tektite (OW)
+    db $FF  ; $0F Blue Leever (OW)
+    ; Mode 0: $10-$1F
+    db $FF  ; $10 Red Leever (OW)
+    db $FF  ; $11 Unknown
+    db $04  ; $12 Vire → SP469
+    db $FF  ; $13 Zol (common)
+    db $FF  ; $14 Gel 1 (common)
+    db $FF  ; $15 Gel 2 (common)
+    db $03  ; $16 Pols Voice → SP358
+    db $04  ; $17 Like Like → SP469
+    db $FF  ; $18 Unknown
+    db $FF  ; $19 Unknown
+    db $FF  ; $1A Peahat (OW)
+    db $FF  ; $1B Blue Keese (common)
+    db $FF  ; $1C Red Keese (common)
+    db $FF  ; $1D Dark Keese (common)
+    db $FF  ; $1E Armos Knight
+    db $FF  ; $1F Boulder Set (OW)
+    ; Mode 0: $20-$2F
+    db $FF  ; $20 Boulder (OW)
+    db $FF  ; $21 Ghini (OW)
+    db $FF  ; $22 Flying Ghini (OW)
+    db $04  ; $23 Red Wizzrobe → SP469
+    db $04  ; $24 Blue Wizzrobe → SP469
+    db $FF  ; $25 Patra Child (spawned)
+    db $FF  ; $26 Patra Child (spawned)
+    db $02  ; $27 Wallmaster → SP127
+    db $02  ; $28 Rope → SP127
+    db $FF  ; $29 Unknown
+    db $02  ; $2A Stalfos → SP127
+    db $FF  ; $2B Bubble 1 (common)
+    db $FF  ; $2C Bubble 2 (common)
+    db $FF  ; $2D Bubble 3 (common)
+    db $FF  ; $2E Whirlwind
+    db $FF  ; $2F Pond Fairy
+    ; Mode 0: $30-$3F (bosses and special)
+    db $03  ; $30 Gibdo → SP358
+    db $05  ; $31 Triple Dodongo → Boss1257
+    db $05  ; $32 Single Dodongo → Boss1257
+    db $06  ; $33 Blue Gohma → Boss3468
+    db $06  ; $34 Red Gohma → Boss3468
+    db $FF  ; $35 Rupee Boss
+    db $FF  ; $36 Hungry Goriya
+    db $FF  ; $37 Zelda
+    db $05  ; $38 Single Digdogger → Boss1257
+    db $05  ; $39 Triple Digdogger → Boss1257
+    db $02  ; $3A Red Lanmola → SP127
+    db $04  ; $3B Blue Lanmola → SP469
+    db $06  ; $3C Manhandla → Boss3468
+    db $05  ; $3D Aquamentus → Boss1257
+    db $07  ; $3E Ganon → Boss9
+    db $FF  ; $3F Guard Fire
+    ; Mode 1: $40-$4F
+    db $FF  ; $40 Standing Fire
+    db $FF  ; $41 Moldorm (common)
+    db $06  ; $42 Gleeok 1 → Boss3468
+    db $06  ; $43 Gleeok 2 → Boss3468
+    db $06  ; $44 Gleeok 3 → Boss3468
+    db $06  ; $45 Gleeok 4 → Boss3468
+    db $FF  ; $46 Gleeok Head (spawned)
+    db $07  ; $47 Patra 1 → Boss9
+    db $07  ; $48 Patra 2 → Boss9
+    db $FF  ; $49 Three Pairs Of Traps
+    db $FF  ; $4A Corner Traps
+    db $FF  ; $4B Old Man
+    db $FF  ; $4C Old Man 2
+    db $FF  ; $4D Old Man 3
+    db $FF  ; $4E Old Man 4
+    db $FF  ; $4F Bomb Upgrader
+    ; Mode 1: $50-$5F
+    db $FF  ; $50 Old Man 5
+    db $FF  ; $51 Mugger
+    db $FF  ; $52 Old Man 6
+    db $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF ; $53-$5F unused
+    db $FF  ; $60 Unknown
+    db $FF  ; $61 Unknown
+    ; Enemy lists: $62-$6F (list ids 0-13)
+    db $FF  ; $62 List 0: Moblins (OW)
+    db $FF  ; $63 List 1: Moblins (OW)
+    db $FF  ; $64 List 2: Peahat/Lynels (OW)
+    db $FF  ; $65 List 3: Lynels (OW)
+    db $FF  ; $66 List 4: Lynels/Leevers (OW)
+    db $FF  ; $67 List 5: Leevers/Peahats (OW)
+    db $FF  ; $68 List 6: Octoroks (OW)
+    db $FF  ; $69 List 7: Octoroks (OW)
+    db $FF  ; $6A List 8: Octoroks (OW)
+    db $FF  ; $6B List 9: Octoroks (OW)
+    db $FF  ; $6C List 10: Moblins/Octoroks (OW)
+    db $FF  ; $6D List 11: Traps/Zol (common)
+    db $FF  ; $6E List 12: Traps/Keese (common)
+    db $FF  ; $6F List 13: Bubble/Zol/Keese (common)
+    ; Enemy lists: $70-$7F (list ids 14-29)
+    db $03  ; $70 List 14: Pols Voice/Gibdo/Keese → SP358
+    db $04  ; $71 List 15: Bubble/Wizzrobes → SP469
+    db $04  ; $72 List 16: Bubble/Vire → SP469
+    db $04  ; $73 List 17: Bubble/Zol/Like-Like → SP469
+    db $03  ; $74 List 18: Bubble/Darknuts/Gibdo → SP358
+    db $02  ; $75 List 19: Bubble/Goriya/Keese → SP127
+    db $04  ; $76 List 20: Traps/Like-Like → SP469
+    db $04  ; $77 List 21: Traps/Wizzrobes → SP469
+    db $03  ; $78 List 22: Pols Voice/Darknuts → SP358
+    db $02  ; $79 List 23: Bubble/Wallmaster → SP127
+    db $02  ; $7A List 24: Goriyas → SP127
+    db $04  ; $7B List 25: Wizzrobes → SP469
+    db $04  ; $7C List 26: Bubble/Like-Like/Wizzrobes → SP469
+    db $04  ; $7D List 27: Bubbles/Wizzrobes → SP469
+    db $03  ; $7E List 28: Bubbles/Darknuts → SP358
+    db $02  ; $7F List 29: Bubbles/Wallmaster → SP127

--- a/src/z1/randomizer/transition_in.asm
+++ b/src/z1/randomizer/transition_in.asm
@@ -125,6 +125,7 @@ transition_to_z1:
     lda #$00 : sta $210d
 
     jsl nes_overlay_init
+    jsl PreConvertSpritePatterns
 
     ; Enable NMI and clear pending interrupts
     cli : lda.l $004210

--- a/src/z1/randomizer/transition_out.asm
+++ b/src/z1/randomizer/transition_out.asm
@@ -144,6 +144,14 @@ backup_wram:
     inx #2
     cpx.w #$0800
     bne -
+
+    ldx #$0000
+-
+    lda.w ExpandedDungeonState, x
+    sta.l !SRAM_Z1_EXPANDED_DUNGEONS, x
+    inx #2
+    cpx.w #$0480
+    bne -
     plp
     rtl
 


### PR DESCRIPTION
This pull request implements expanded dungeon support and a new system for pre-converted sprite pattern data in the Z1 randomizer, enabling unique dungeon layouts and dynamic sprite graphics for each dungeon. Key changes include allocating new SRAM and WRAM regions, adding routines for copying expanded dungeon data, and introducing a system to pre-convert and DMA sprite patterns for correct enemy graphics. Several hooks and labels are added or updated to support these features.

**Expanded Dungeon Support:**

- Allocated new SRAM region for expanded dungeon state backup and updated the memory map and defines accordingly (`ideas.md`, `src/defines.asm`). [[1]](diffhunk://#diff-425154e9e63ea7e7bf0b906debfb4d834c2e4e8adfb069b2be1006343338b51dL83-R86) [[2]](diffhunk://#diff-2f7631c3809de0a8eed06ae13581e360e7e8b4ef50328a16e3380b0503eae514R64)
- Added `CopyBlock_LevelData` routine and related hooks to support copying dungeon level data from expanded banks, allowing all 9 dungeons to have unique layouts (`src/z1/randomizer/dungeons.asm`, `src/z1/randomizer/hooks.asm`, `src/z1/randomizer/common.asm`). [[1]](diffhunk://#diff-f7dce43fe2e6d030255820864f7296635e63c37c8fc9bf68581558f9629a2906R1-R38) [[2]](diffhunk://#diff-04906d494cf4f0fc7eb3218a8fd0851140bae4ec24f68df19f42d5207f306ddcR165-R183) [[3]](diffhunk://#diff-995a53ac21cbaf2725a6300a9972dd08356e4a765c6c40813a7f963caea697abR36-R52)
- Updated boot and transition code to handle new buffer sizes and SRAM/WRAM regions for expanded dungeons (`src/m1/init.asm`, `src/z1/init.asm`, `src/motherbrain/transition.asm`). [[1]](diffhunk://#diff-70b59cdb74a5fe57cd1482fe68a8b5512174c1efadd2fd14bec98d539e852bb6L12-R12) [[2]](diffhunk://#diff-01239aba758369609bd9e337b50e1af0003bac20e72e936878a5cff2ba314eadL13-R13) [[3]](diffhunk://#diff-dafc71c8f78308212a9edfd94a12f506db2b0b2c42c06275c81ab591f48b0065R145-R148) [[4]](diffhunk://#diff-dafc71c8f78308212a9edfd94a12f506db2b0b2c42c06275c81ab591f48b0065L172-R173)

**Sprite Pattern Pre-Conversion and Dynamic Swapping:**

- Implemented a system to pre-convert all unique NES 2bpp sprite pattern blocks to SNES 4bpp format at boot and on transition, storing them in WRAM for fast DMA (`src/z1/randomizer/spritepatterns.asm`).
- Added routines and hooks to dynamically swap sprite and boss pattern sets during room transitions, ensuring correct enemy graphics by tracking and updating the current set in WRAM (`src/z1/randomizer/spritepatterns.asm`, `src/z1/common.asm`, `src/z1/randomizer/hooks.asm`). [[1]](diffhunk://#diff-8a3420e24367399eb17930e72e09c49079677e2fd5409e08f0ce47dc4e018936R1-R355) [[2]](diffhunk://#diff-fead81e1385912e6e61bed1c030526631332e051b29a666869c7b26d48352f5eR275-R298) [[3]](diffhunk://#diff-04906d494cf4f0fc7eb3218a8fd0851140bae4ec24f68df19f42d5207f306ddcR165-R183)
- Updated label definitions and initialization code to support new variables and pre-conversion routines (`src/z1/labels.asm`, `src/z1/init.asm`). [[1]](diffhunk://#diff-67390a324abf00b822ffbf2e959e6340f548aa1ad887174c411a99f29a4cdf16R617-R618) [[2]](diffhunk://#diff-67390a324abf00b822ffbf2e959e6340f548aa1ad887174c411a99f29a4cdf16R635-R636) [[3]](diffhunk://#diff-67390a324abf00b822ffbf2e959e6340f548aa1ad887174c411a99f29a4cdf16R664-R671) [[4]](diffhunk://#diff-01239aba758369609bd9e337b50e1af0003bac20e72e936878a5cff2ba314eadR34-R38)

**Extended Item Handling:**

- Modified item loading routines to support extended dungeon data and item tables, including logic to select the correct source based on dungeon configuration (`src/z1/randomizer/newitems.asm`). [[1]](diffhunk://#diff-4fc018284bf22164d0d38855d4b9af62b3244d47e6e39304d243f964c2575f12R109-R119) [[2]](diffhunk://#diff-4fc018284bf22164d0d38855d4b9af62b3244d47e6e39304d243f964c2575f12R134-R150)

**Miscellaneous:**

- Fixed a print typo in the extended room items table (`src/z1/randomizer/tables.asm`).
- Included new modules in the randomizer's main assembly file (`src/z1/randomizer/main.asm`).