### PR TITLE
Z1 special palette entry regression fix for v0.5

### DIFF
--- a/src/z1/randomizer/transition_in.asm
+++ b/src/z1/randomizer/transition_in.asm
@@ -52,6 +52,8 @@ transition_to_z1:
     bne -    
 
     sep #$30
+    ; Prevent transition-time PPU hooks from treating startup as grayscale.
+    lda #$0e : sta PPUCNT1ZP
     jsl UploadItemPalettes
     jsl nes_initSpecialPaletteEntry
 
@@ -111,9 +113,6 @@ transition_to_z1:
     stz $11     
     stz $13     ; Clear submode
     stz $E3     ; Clear sprite 0 flag
-
-    ; Set rendering to off
-    lda #$0f : sta PPUCNT1ZP
 
     ; Reset scrolling
     stz.b CurVScroll

--- a/src/z1/snes.asm
+++ b/src/z1/snes.asm
@@ -1261,6 +1261,15 @@ QueueGrayscalePalette:
     stx.w TransferTmp
 
     ldx.w TransferCount
+    ; The priority mask uses $71 as an independent black color normally.
+    cpx.w #$0020
+    bne .cachedColor
+    lda.w GrayscalePaletteState
+    bne .cachedColor
+    lda #$0d                  ; NesPalTable[$0d] = pure black
+    bra .lookup
+
+.cachedColor
     lda.l GrayscalePaletteNesIndexes, x
     tax
     lda.w CurrentNesPalette, x


### PR DESCRIPTION
Fix the special priority palette entry $71 by modifying the PPUCNT1ZP transition value.  This also avoids an unnecessary cgram block write.

Correct the special color's source as well in QueueGrayscalePalette(). Fixes dungeon priority tile color regression in v0.5.